### PR TITLE
Fixed link to sentiment analysis in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Set custom claims for Firebase Auth users from values set in Firestore.
 
 Write documents to Firestore at an arbitrary time in the future.
 
-### [Sentiment analysis](/firestore-schedule-writes#schedule-firestore-writes)
+### [Sentiment analysis](/firestore-sentiment-analysis#sentiment-analysis)
 
 Determines the sentiment magnitude and score for given text values in Firestore.
 


### PR DESCRIPTION
Fixes the REAME's link to sentiment analysis extension previously pointing to https://github.com/FirebaseExtended/experimental-extensions/tree/next/firestore-schedule-writes#schedule-firestore-writes.

- [x] Appropriate changes to README are included in PR
