### PR TITLE
Update README generation script

### DIFF
--- a/firestore-auth-claims/README.md
+++ b/firestore-auth-claims/README.md
@@ -12,12 +12,12 @@
 
 ### Console
 
-[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?sourceName=projects/firebasemods/sources/75aead28-f3f6-424d-8212-8e715cb6f341)
+[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?ref=firebase/firestore-auth-claims)
 
 ### Firebase CLI
 
 ```bash
-firebase ext:install firestore-auth-claims --project=<your-project-id>
+firebase ext:install firebase/firestore-auth-claims --project=<your-project-id>
 ```
 
 > Learn more about installing extensions in the Firebase Extensions documentation: [console](https://firebase.google.com/docs/extensions/install-extensions?platform=console), [CLI](https://firebase.google.com/docs/extensions/install-extensions?platform=cli)

--- a/firestore-bundle-server/README.md
+++ b/firestore-bundle-server/README.md
@@ -1,6 +1,6 @@
 # Firestore Bundle Server
 
-**Author**: undefined
+**Author**: Firebase (**[https://firebase.google.com](https://firebase.google.com)**)
 
 **Description**: Provides cached serving of Firestore bundles.
 

--- a/firestore-bundle-server/README.md
+++ b/firestore-bundle-server/README.md
@@ -1,8 +1,8 @@
 # Firestore Bundle Server
 
-**Author**: Firebase (**[https://firebase.google.com](https://firebase.google.com)**)
+**Author**: undefined
 
-**Description**: Serves Firestore Data Bundles based on specs defined as Firestore Documents, with the ability to use Hosting and Storage as cache.
+**Description**: Provides cached serving of Firestore bundles.
 
 ---
 
@@ -12,19 +12,24 @@
 
 ### Console
 
-[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?sourceName=projects/firebasemods/sources/75aead28-f3f6-424d-8212-8e715cb6f341)
+[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?ref=firebase/firestore-bundle-server)
 
 ### Firebase CLI
 
 ```bash
-firebase ext:install firestore-bundle-server --project=<your-project-id>
+firebase ext:install firebase/firestore-bundle-server --project=<your-project-id>
 ```
 
 > Learn more about installing extensions in the Firebase Extensions documentation: [console](https://firebase.google.com/docs/extensions/install-extensions?platform=console), [CLI](https://firebase.google.com/docs/extensions/install-extensions?platform=cli)
 
 ---
 
-**Details**: This extension will automatically set up a Cloud Function instance serving HTTP requests. The Function instance listens to a specified Firestore collection, whose documents are
+**Details**: Use this extension to build Firestore data bundle files via HTTP requests to a Cloud Function instance, and manage the caching strategy for the built bundle files. Firestore data bundles are static data files built from Firestore documents and query snapshots;
+learn more about Firestore data bundles in the [Firestore guides](https://firebase.google.com/docs/firestore/bundles).
+
+#### How it works
+
+The extension sets up a Cloud Function instance serving HTTP requests. The Function instance listens to a specified Firestore collection, whose documents are
 specifications for assembly of Firestore data bundle files.
 
 Clients send HTTP requests specifying what bundle specification to build, along with values (via HTTP request query parameters) to parameterize the
@@ -33,7 +38,15 @@ specifications.
 Depending on the bundle specification, the requested bundle might be returned from client's cache, Firebase Hosting cache or a Cloud Storage file. When no
 cache is found, queries will run against the Firestore back-end to get the data and build the bundle.
 
-# Billing
+#### Additional setup
+
+Before installing this extension, you'll need to set up these services in your Firebase project:
+
+- [Set up Cloud Firestore](https://firebase.google.com/docs/firestore/quickstart)
+- [Set up Cloud Functions](https://firebase.google.com/docs/functions)
+
+#### Billing
+
 This extension uses other Firebase or Google Cloud Platform services which may have associated charges:
 
 - Cloud Firestore
@@ -44,14 +57,15 @@ When you use Firebase Extensions, you're only charged for the underlying resourc
 
 **Configuration Parameters:**
 
-- BUNDLESPEC_COLLECTION: Path to the Firestore collection whose documents are specifications of
-  bundles the extension will build.
+- Collection to store bundle specification documents: Path to the Firestore collection whose documents are specifications of bundles the extension will build.
 
-- BUNDLE_STORAGE_BUCKET: The Cloud Storage bucket to save the built bundle files. This applies when
-  the bundle specification has `fileCache` enabled.
+- Google Cloud Storage bucket to save the built bundle files: The Cloud Storage bucket to save the built bundle files. This applies when the bundle specification has `fileCache` enabled.
 
-- STORAGE_PREFIX: The prefix for all the bundle files built and saved in Cloud Storage.
-  This applies when the bundle specification has `fileCache` enabled.
+- Prefix to use for bundle files saved in Google Cloud Storage.: The prefix for all the bundle files built and saved in Cloud Storage. This applies when the bundle specification has `fileCache` enabled.
+
+**Cloud Functions:**
+
+- **serve:** HTTPS function that serves bundled content from Cloud Storage cache or by dynamically building.
 
 **Access Required**:
 
@@ -59,5 +73,5 @@ This extension will operate with the following project IAM roles:
 
 - datastore.user (Reason: Allows the extension to read configuration and build bundles from Firestore.)
 
-- storage.objectAdmin (Reason: Allows the extension to save built bundles in Cloud Storage.)
+- storage.objectAdmin (Reason: Allows the extension to save built bundles in Cloud Storage)
 

--- a/firestore-schedule-writes/README.md
+++ b/firestore-schedule-writes/README.md
@@ -12,12 +12,12 @@
 
 ### Console
 
-[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?sourceName=projects/firebasemods/sources/3775989a-1e6b-4d63-a13d-79b528f381cd)
+[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?ref=firebase/firestore-schedule-writes)
 
 ### Firebase CLI
 
 ```bash
-firebase ext:install firestore-schedule-writes --project=<your-project-id>
+firebase ext:install firebase/firestore-schedule-writes --project=<your-project-id>
 ```
 
 > Learn more about installing extensions in the Firebase Extensions documentation: [console](https://firebase.google.com/docs/extensions/install-extensions?platform=console), [CLI](https://firebase.google.com/docs/extensions/install-extensions?platform=cli)

--- a/firestore-sentiment-analysis/README.md
+++ b/firestore-sentiment-analysis/README.md
@@ -12,12 +12,12 @@
 
 ### Console
 
-[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?sourceName=projects/firebasemods/sources/33387d07-e01d-4b40-b718-c935730bb9c6)
+[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?ref=firebase/firestore-sentiment-analysis)
 
 ### Firebase CLI
 
 ```bash
-firebase ext:install firestore-sentiment-analysis --project=<your-project-id>
+firebase ext:install firebase/firestore-sentiment-analysis --project=<your-project-id>
 ```
 
 > Learn more about installing extensions in the Firebase Extensions documentation: [console](https://firebase.google.com/docs/extensions/install-extensions?platform=console), [CLI](https://firebase.google.com/docs/extensions/install-extensions?platform=cli)

--- a/firestore-shorten-urls-dynamic-links/README.md
+++ b/firestore-shorten-urls-dynamic-links/README.md
@@ -12,12 +12,12 @@
 
 ### Console
 
-[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?sourceName=projects/firebasemods/sources/eb2b3e3a-4ef1-4998-93c7-8f541e8c918e)
+[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?ref=firebase/firestore-shorten-urls-dynamic-links)
 
 ### Firebase CLI
 
 ```bash
-firebase ext:install firestore-shorten-urls-dynamic-links --project=<your-project-id>
+firebase ext:install firebase/firestore-shorten-urls-dynamic-links --project=<your-project-id>
 ```
 
 > Learn more about installing extensions in the Firebase Extensions documentation: [console](https://firebase.google.com/docs/extensions/install-extensions?platform=console), [CLI](https://firebase.google.com/docs/extensions/install-extensions?platform=cli)

--- a/package.json
+++ b/package.json
@@ -21,11 +21,9 @@
     "url": "https://github.com/FirebaseExtended/experimental-extensions/issues"
   },
   "devDependencies": {
+    "firebase-tools": "^9.9.0",
     "lerna": "^3.4.3",
     "prettier": "^2.2.1",
     "typescript": "^4.1.3"
-  },
-  "dependencies": {
-    "node-fetch": "^2.6.1"
   }
 }

--- a/storage-image-labeling/README.md
+++ b/storage-image-labeling/README.md
@@ -1,8 +1,8 @@
-# Image Text Extraction
+# Image Labeling
 
 **Author**: Firebase (**[https://firebase.google.com](https://firebase.google.com)**)
 
-**Description**: Extracts text from images uploaded to storage and writes extracted text to Firestore.
+**Description**: Performs image labeling on images uploaded to Storage and writes labels to Firestore.
 
 ---
 
@@ -12,19 +12,19 @@
 
 ### Console
 
-[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?ref=firebase/storage-extract-image-text)
+[![Install this extension in your Firebase project](../install-extension.png?raw=true "Install this extension in your Firebase project")](https://console.firebase.google.com/project/_/extensions/install?ref=firebase/storage-image-labeling)
 
 ### Firebase CLI
 
 ```bash
-firebase ext:install firebase/storage-extract-image-text --project=<your-project-id>
+firebase ext:install firebase/storage-image-labeling --project=<your-project-id>
 ```
 
 > Learn more about installing extensions in the Firebase Extensions documentation: [console](https://firebase.google.com/docs/extensions/install-extensions?platform=console), [CLI](https://firebase.google.com/docs/extensions/install-extensions?platform=cli)
 
 ---
 
-**Details**: This extension will extract text from any `jpg` or `png` images uploaded to Cloud Storage and write the extracted text to Firestore.
+**Details**: This extension will label (classify) from any `jpg` or `png` images uploaded to Cloud Storage and write the labels to Firestore.
 
 # Billing
 
@@ -43,13 +43,13 @@ When you use Firebase Extensions, you're only charged for the underlying resourc
 
 - Cloud Functions location: Where do you want to deploy the functions created for this extension? You usually want a location close to your database. Realtime Database instances are located in `us-central1`. For help selecting a location, refer to the [location selection guide](https://firebase.google.com/docs/functions/locations).
 
-- Cloud Storage bucket for images: To which Cloud Storage bucket will you upload images from which you want to extract text?
+- Cloud Storage bucket for images: To which Cloud Storage bucket will you upload images on which you want to perform labelling?
 
-- Collection path: What is the path to the collection where extracted text will be written to.
+- Collection path: What is the path to the collection where labels will be written to.
 
 **Cloud Functions:**
 
-- **extractText:** Listens to incoming Storage documents, executes OCR on them and writes extracted text to Firestore into a preconfigured collection.
+- **labelImage:** Listens to incoming Storage documents, executes image labeling on them and writes labels back to Storage into a preconfigured location.
 
 **APIs Used**:
 

--- a/storage-image-labeling/functions/package.json
+++ b/storage-image-labeling/functions/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "functions",
+  "name": "storage-image-labeling",
   "scripts": {
     "lint": "eslint \"src/**/*\"",
     "build": "tsc",
@@ -7,7 +7,8 @@
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "generate-readme": "node ../../generate-experimental-readme.js storage-image-labeling > ../README.md"
   },
   "engines": {
     "node": "12"


### PR DESCRIPTION
Update the generate-readmes script to:

- add the `firebase` producer ID to CLI commands
- use `ref` instead of `sourceName` in console install links

With these changes, we won't have to regenerate readmes after every release, since the `ref` in the console install link is no longer pointing to a specific version.