### PR TITLE
fix schedule-firestore-writes: error message even on success

### DIFF
--- a/firestore-schedule-writes/functions/src/index.ts
+++ b/firestore-schedule-writes/functions/src/index.ts
@@ -134,16 +134,18 @@ async function processWrite(
     switch (CLEANUP) {
       case "DELETE":
         await ref.delete();
+        break;
       case "KEEP":
         await ref.update({
           state: "DELIVERED",
           updateTime: admin.firestore.FieldValue.serverTimestamp(),
           endTime: admin.firestore.FieldValue.serverTimestamp(),
         });
+        break;
     }
   }
 
-  return { success: !!error, error, id: ref.id };
+  return { success: !error, error, id: ref.id };
 }
 
 async function resetStuck(): Promise<void> {


### PR DESCRIPTION
Fix for this issue: #31 

Breaks were missing in the switch case. In the case of `CLEANUP === "DELETE"` both cases would be executed. The second case would try to update the document that was deleted in the first case resulting in the error.

Once this was fixed a second bug occurred. The return value of the function was wrong because `error` was negated twice instead of only once.

I couldn’t find any tests so I deployed the function to one of my firebase projects and it worked correctly.

