### PR TITLE
feat(storage-mirror-firestore): added tombstone cleanup task

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,8 @@
     "firestore-sentiment-analysis/functions",
     "storage-extract-image-text/functions",
     "storage-image-labeling/functions",
-    "storage-mirror-firestore/functions"
+    "storage-mirror-firestore/functions",
+    "storage-mirror-firestore/stress_test"
   ],
   "version": "0.0.0"
 }

--- a/storage-mirror-firestore/POSTINSTALL.md
+++ b/storage-mirror-firestore/POSTINSTALL.md
@@ -58,11 +58,12 @@ const itemsSnapshot = await firestore
 
 ### (Optional) Backfill
 
-If you already have objects in GCS that should be mirrored to Firestore, you can use the backfill tool in the stress_test subdirectory. If you application default credentials are set up, you can just run `npm run-script start -- backfill` from that directory.
+If you already have objects in GCS that should be mirrored to Firestore, you can use the backfill tool in the stress_test subdirectory. If your application default credentials are set up, you can just run `npm run-script start -- backfill` from that directory.
 
 ### (Optional) Cleaning Up Tombstones
 
-*TODO*: Implement clean-up tool for tombstone documents
+If you want to cleanup tombstone records, you can use the cleanup tool in the stress_test subdirectory. If your application default credentials are set up, you can just run `npm run-script start -- clean-tombstones` from that directory. You can optionally also specify the
+`--instance-id <extension_instance_id>` and `--project <project_id>` params for this script.
 
 ### Monitoring
 

--- a/storage-mirror-firestore/stress_test/bin/driver.ts
+++ b/storage-mirror-firestore/stress_test/bin/driver.ts
@@ -797,9 +797,6 @@ const cleanTombstonesCommand = new commander.Command("clean-tombstones")
           document.exists &&
           document.ref.path.startsWith(instance.config.params.FIRESTORE_ROOT)
         ) {
-          console.log(
-            `Found item tombstone record at path '${document.ref.path}'`
-          );
           countOfTombstones++;
           writer.delete(document.ref);
         }
@@ -820,9 +817,6 @@ const cleanTombstonesCommand = new commander.Command("clean-tombstones")
           document.exists &&
           document.ref.path.startsWith(instance.config.params.FIRESTORE_ROOT)
         ) {
-          console.log(
-            `Found prefix tombstone record at path '${document.ref.path}'`
-          );
           countOfTombstones++;
           writer.delete(document.ref);
         }

--- a/storage-mirror-firestore/stress_test/bin/driver.ts
+++ b/storage-mirror-firestore/stress_test/bin/driver.ts
@@ -828,7 +828,7 @@ const cleanTombstonesCommand = new commander.Command("clean-tombstones")
 
     if (countOfTombstones > 0) {
       console.log(
-        `\n-- Found a total of ${countOfTombstones} tombstone records, deleting...\n`
+        `Found a total of ${countOfTombstones} tombstone documents to remove. Cleaning up documents...`
       );
       await writer.close();
       console.log(`Cleanup successful!`);

--- a/storage-mirror-firestore/stress_test/bin/driver.ts
+++ b/storage-mirror-firestore/stress_test/bin/driver.ts
@@ -786,8 +786,11 @@ const cleanTombstonesCommand = new commander.Command("clean-tombstones")
     const itemTombstonesCollectionGroup = admin
       .firestore()
       .collectionGroup(instance.config.params.ITEMS_TOMBSTONES_NAME);
+    // Using a partition size that worked well in testing on other
+    // extension scripts (e.g. the BigQuery import script).
+    const partitionSize = 300;
     const itemTombstonesPartitions =
-      itemTombstonesCollectionGroup.getPartitions(42);
+      itemTombstonesCollectionGroup.getPartitions(partitionSize);
     for await (const partition of itemTombstonesPartitions) {
       const partitionSnapshot = await partition.toQuery().get();
       const documents = partitionSnapshot.docs;

--- a/storage-mirror-firestore/stress_test/bin/driver.ts
+++ b/storage-mirror-firestore/stress_test/bin/driver.ts
@@ -786,9 +786,8 @@ const cleanTombstonesCommand = new commander.Command("clean-tombstones")
     const itemTombstonesCollectionGroup = admin
       .firestore()
       .collectionGroup(instance.config.params.ITEMS_TOMBSTONES_NAME);
-    const itemTombstonesPartitions = itemTombstonesCollectionGroup.getPartitions(
-      42
-    );
+    const itemTombstonesPartitions =
+      itemTombstonesCollectionGroup.getPartitions(42);
     for await (const partition of itemTombstonesPartitions) {
       const partitionSnapshot = await partition.toQuery().get();
       const documents = partitionSnapshot.docs;
@@ -810,9 +809,8 @@ const cleanTombstonesCommand = new commander.Command("clean-tombstones")
     const prefixTombstonesCollectionGroup = admin
       .firestore()
       .collectionGroup(instance.config.params.PREFIXES_TOMBSTONES_NAME);
-    const prefixTombstonesPartitions = prefixTombstonesCollectionGroup.getPartitions(
-      42
-    );
+    const prefixTombstonesPartitions =
+      prefixTombstonesCollectionGroup.getPartitions(42);
     for await (const partition of prefixTombstonesPartitions) {
       const partitionSnapshot = await partition.toQuery().get();
       const documents = partitionSnapshot.docs;

--- a/storage-mirror-firestore/stress_test/bin/driver.ts
+++ b/storage-mirror-firestore/stress_test/bin/driver.ts
@@ -711,6 +711,137 @@ const backfillCmd = new commander.Command("backfill")
     spinner.succeed(`Mirrored ${succeeded} paths in ${elapsed}s.`);
   });
 
+const cleanTombstonesCommand = new commander.Command("clean-tombstones")
+  .allowUnknownOption(false)
+  .description("delete tombstone records from firestore")
+  .option(
+    "--project <project_id>",
+    "project id which has the extension installed"
+  )
+  .option(
+    "--instance-id <extension_instance_id>",
+    "instance id of the extension (which can be found with `firebase ext:list`).",
+    "storage-mirror-firestore"
+  )
+  .action(async (command: commander.Command) => {
+    interface CommandWithOpts extends commander.Command {
+      project?: string;
+      instanceId?: string;
+    }
+    interface ExtensionInstance {
+      state: string;
+      config: {
+        params: {
+          ITEMS_TOMBSTONES_NAME: string;
+          PREFIXES_TOMBSTONES_NAME: string;
+          FIRESTORE_ROOT: string;
+        };
+      };
+    }
+
+    const options = command as CommandWithOpts;
+    const auth = new GoogleAuth({
+      scopes: ["https://www.googleapis.com/auth/firebase.readonly"],
+    });
+    const authClient = await auth.getClient();
+    const projectId = options.project || (await auth.getProjectId());
+
+    let instance: ExtensionInstance;
+    let url = `https://firebaseextensions.googleapis.com/v1beta/projects/${projectId}/instances/${options.instanceId}`;
+    try {
+      const response = await authClient.request({ url });
+      instance = response.data as ExtensionInstance;
+    } catch (e) {
+      if (e.code === 404) {
+        console.error(
+          `Extension instance '${options.instanceId}' on project '${projectId}' was not found.`
+        );
+        process.exit(1);
+      }
+      throw e;
+    }
+
+    if (instance.state !== "ACTIVE") {
+      console.error(
+        `Extension instance '${options.instanceId}' on project '${projectId}' is not active.`
+      );
+      return;
+    }
+
+    const prompt = `Are you sure you want to delete tombstone records from Firestore for the project '${projectId}' and instance '${options.instanceId}'?`;
+    if (!(await confirm(prompt))) {
+      process.exit(0);
+    }
+
+    console.log("\nScanning project for tombstone records...\n");
+
+    admin.initializeApp({
+      credential: admin.credential.applicationDefault(),
+      projectId: projectId,
+    });
+
+    let countOfTombstones = 0;
+    const writer = admin.firestore().bulkWriter();
+
+    const itemTombstonesCollectionGroup = admin
+      .firestore()
+      .collectionGroup(instance.config.params.ITEMS_TOMBSTONES_NAME);
+    const itemTombstonesPartitions = itemTombstonesCollectionGroup.getPartitions(
+      42
+    );
+    for await (const partition of itemTombstonesPartitions) {
+      const partitionSnapshot = await partition.toQuery().get();
+      const documents = partitionSnapshot.docs;
+      for (const document of documents) {
+        // Only delete if the path matches the extensions configured Firestore root.
+        if (
+          document.exists &&
+          document.ref.path.startsWith(instance.config.params.FIRESTORE_ROOT)
+        ) {
+          console.log(
+            `Found item tombstone record at path '${document.ref.path}'`
+          );
+          countOfTombstones++;
+          writer.delete(document.ref);
+        }
+      }
+    }
+
+    const prefixTombstonesCollectionGroup = admin
+      .firestore()
+      .collectionGroup(instance.config.params.PREFIXES_TOMBSTONES_NAME);
+    const prefixTombstonesPartitions = prefixTombstonesCollectionGroup.getPartitions(
+      42
+    );
+    for await (const partition of prefixTombstonesPartitions) {
+      const partitionSnapshot = await partition.toQuery().get();
+      const documents = partitionSnapshot.docs;
+      for (const document of documents) {
+        // Only delete if the path matches the extensions configured Firestore root.
+        if (
+          document.exists &&
+          document.ref.path.startsWith(instance.config.params.FIRESTORE_ROOT)
+        ) {
+          console.log(
+            `Found prefix tombstone record at path '${document.ref.path}'`
+          );
+          countOfTombstones++;
+          writer.delete(document.ref);
+        }
+      }
+    }
+
+    if (countOfTombstones > 0) {
+      console.log(
+        `\n-- Found a total of ${countOfTombstones} tombstone records, deleting...\n`
+      );
+      await writer.close();
+      console.log(`Cleanup successful!`);
+    } else {
+      console.log(`No tombstone records found.`);
+    }
+  });
+
 const checkCmd = new commander.Command("check")
   .allowUnknownOption(false)
   .description("check for consistency between GCS and Firestore")
@@ -1249,7 +1380,7 @@ const cleanFirestore = async (
     while (prefixes.length > 0) {
       const currPrefix = prefixes.pop() as string;
       // Paginate requests to Firestore to preserve memory.
-      const prefixesPromise = new Promise(async (resolve, reject) => {
+      const prefixesPromise = new Promise<void>(async (resolve, reject) => {
         const prefixesSnapshot = await firestore
           .collection(`${currPrefix}/${constants.prefixes}`)
           .get();
@@ -1316,6 +1447,7 @@ const rootCmd = new commander.Command("driver")
   .addCommand(writeCmd)
   .addCommand(checkCmd)
   .addCommand(backfillCmd)
+  .addCommand(cleanTombstonesCommand)
   .addCommand(cleanCmd);
 rootCmd.parseAsync(process.argv).catch((e) => {
   console.error(e);

--- a/storage-mirror-firestore/stress_test/functions/package.json
+++ b/storage-mirror-firestore/stress_test/functions/package.json
@@ -8,7 +8,7 @@
     "node": "12"
   },
   "dependencies": {
-    "firebase-admin": "^8.0.0",
+    "firebase-admin": "^9.11.0",
     "firebase-functions": "^3.7.0"
   },
   "devDependencies": {

--- a/storage-mirror-firestore/stress_test/package.json
+++ b/storage-mirror-firestore/stress_test/package.json
@@ -22,7 +22,7 @@
     "await-semaphore": "^0.1.3",
     "commander": "^6.0.0",
     "faker": "github:marak/Faker.js",
-    "firebase-admin": "^8.0.0",
+    "firebase-admin": "^9.11.0",
     "firebase-functions": "^3.7.0",
     "google-auth-library": "^6.0.6",
     "inquirer": "^7.3.3",


### PR DESCRIPTION
Adding tombstones cleanup task, which does the following.

 - Prompt for confirmation on project and extension instance id
 - Discover and list current tombstones via query partitions
 - Delete all tombstones via bulk writer


Open question: should this allow cleaning up based on a date, e.g. only delete tombstones after a certain date?