### PR TITLE
storage-mirror-firestore - fix - faker import

### DIFF
--- a/storage-mirror-firestore/stress_test/package.json
+++ b/storage-mirror-firestore/stress_test/package.json
@@ -21,7 +21,7 @@
     "@types/inquirer": "^6.5.0",
     "await-semaphore": "^0.1.3",
     "commander": "^6.0.0",
-    "faker": "github:marak/Faker.js",
+    "faker": "^5.5.3",
     "firebase-admin": "^8.0.0",
     "firebase-functions": "^3.7.0",
     "google-auth-library": "^6.0.6",


### PR DESCRIPTION
**Faker package after 5.5.3** generates *“What really happened with Aaron Swartz?”* see Verge [article](https://www.theverge.com/2022/1/9/22874949/developer-corrupts-open-source-libraries-projects-affected) .

Or, optionally using '@faker-js/faker' package https://fakerjs.dev/update.html#i-heard-something-happened-what-s-the-tldr

Welcome to the Experimental Extensions repo! If this PR adds a new extension,
thank you, and please make sure you follow the steps below! Otherwise, you can
disregard this message.

- [x] The new extension's id roughly follows the pattern
      `[firebase-product]-[action]-[noun]`, like `storage-resize-images`
- [ ] The following match the extension's id:
  - [ ] The folder that contains the extension (`my-new-extension/`)
  - [ ] The `name` field of `my-new-extension/functions/package.json`
  - [ ] The `name` field of `my-new-extension/extension.yaml`
  - [ ] A new entry in the `packages` array of the `lerna.json` file in the
        repository's root
- [ ] I've added a `generate-readme` script to
      `my-new-extension/functions/package.json` that matches the other
      extensions in the repository
- [ ] I've run the following npm commands at the root of the repository:
  - [ ] `npm install`
  - [ ] `npm run generate-readmes`
  - [ ] `npm run format`
