### PR TITLE
handle fetch api errors

### DIFF
--- a/firestore-shorten-urls-dynamic-links/functions/src/index.ts
+++ b/firestore-shorten-urls-dynamic-links/functions/src/index.ts
@@ -100,7 +100,12 @@ class FirestoreDynamicLinksUrlShortener extends FirestoreUrlShortener {
         method: "POST",
         body: JSON.stringify(requestBody),
       });
-      const { shortLink: shortUrl } = await response.json();
+      const responseBody = await response.json();
+      if (!response.ok) {
+        this.logs.error(responseBody.error.message);
+        return;
+      }
+      const shortUrl = responseBody.shortLink;
 
       this.logs.shortenUrlComplete(shortUrl);
 


### PR DESCRIPTION
The `fetch` API doesn't throw errors if the request fails by default (See: https://stackoverflow.com/q/38235715/10278150). This causes silent errors and unclear logs.

Updated to log a clear error and end the function execution if the request fails.

**Before**
![Screen Shot 2022-04-25 at 13 53 36](https://user-images.githubusercontent.com/35961879/165077259-2526e52b-0f63-4356-a0b4-59b464337ac4.png)

**After**
![Screen Shot 2022-04-25 at 13 56 05](https://user-images.githubusercontent.com/35961879/165077265-f4652fba-dcf6-4da4-bb84-9d14b362d4a6.png)
 