### PR TITLE
fix multiselect type

### DIFF
--- a/firestore-nlp-extension/extension.yaml
+++ b/firestore-nlp-extension/extension.yaml
@@ -130,7 +130,7 @@ params:
     label: NLP task to perform on the input data.
     description: >
       Select one or more NLP tasks to perform on the input data.
-    type: multiselect
+    type: multiSelect
     options:
       - label: Entity extraction
         value: ENTITY
@@ -145,7 +145,7 @@ params:
     label: Entities to filter.
     description: >
       If you perform entity extraction, which entity types are you interested in? (ignored if entity extraction is not performed)
-    type: multiselect
+    type: multiSelect
     options:
       - label: Location
         value: LOCATION

--- a/firestore-nlp-extension/functions/package.json
+++ b/firestore-nlp-extension/functions/package.json
@@ -26,7 +26,7 @@
     "prettier": "1.15.3",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.1.2",
-    "typescript": "^3.8.0"
+    "typescript": "^4.6.4"
   },
   "private": true
 }

--- a/firestore-schedule-writes/extension.yaml
+++ b/firestore-schedule-writes/extension.yaml
@@ -121,7 +121,12 @@ params:
       collection.
   - param: MERGE_WRITE
     label: Merge Writes
-    type: boolean
+    type: select
+    options:
+      - label: False
+        value: false
+      - label: True
+        value: true
     description: >-
       When true, writes to existing documents are merged with existing data.
       When false, writes to existing documents overwrite existing data.


### PR DESCRIPTION
fix the following error when publishing
```
Error: The extension.yaml has the following errors: 
  - Invalid type multiselect for param TASKS. Valid types are select, multiSelect, string, selectResource
  - Invalid type multiselect for param ENTITY_TYPES. Valid types are select, multiSelect, string, selectResource
```

and also `boolean` type